### PR TITLE
Update serverless example readme to include db setup

### DIFF
--- a/javascript/serverless/README.md
+++ b/javascript/serverless/README.md
@@ -13,6 +13,7 @@ If you are not planning to deploy to Vercel, Netlify, etc, please just use any o
 - Install dependencies `yarn install`
 - Init a railway project `yarn railway init`
 - Open the project in the Railway dashboard `yarn railway open`
+- Install the Postgres plugin from the Railway dashboard
 - Run the code `yarn start`
 
 The time should be printed


### PR DESCRIPTION
This change clarifies the getting started section to include a step to install the pg plugin. 

Without first installing the Postgres plugin I get the following error when trying to run the project:

```shell
$ railway run node src/index.js 
Error: connect ECONNREFUSED 127.0.0.1:5432
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1128:14) {
  errno: 'ECONNREFUSED',
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 5432
}
/Users/evanboyle/garbage/rwfork/examples/javascript/serverless/src/index.js:8
  console.log(res.rows);
                  ^

TypeError: Cannot read property 'rows' of undefined
    at /Users/evanboyle/garbage/rwfork/examples/javascript/serverless/src/index.js:8:19
    at PendingItem.callback (/Users/evanboyle/garbage/rwfork/examples/javascript/serverless/node_modules/pg-pool/index.js:345:16)
    at /Users/evanboyle/garbage/rwfork/examples/javascript/serverless/node_modules/pg-pool/index.js:237:23
    at Connection.connectingErrorHandler (/Users/evanboyle/garbage/rwfork/examples/javascript/serverless/node_modules/pg/lib/client.js:213:14)
    at Connection.emit (events.js:210:5)
    at Socket.reportStreamError (/Users/evanboyle/garbage/rwfork/examples/javascript/serverless/node_modules/pg/lib/connection.js:57:10)
    at Socket.emit (events.js:210:5)
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```